### PR TITLE
Update self sufficiency contract for newer USI-LS

### DIFF
--- a/BaseMissions/BaseSelf-Sufficiency.cfg
+++ b/BaseMissions/BaseSelf-Sufficiency.cfg
@@ -72,24 +72,73 @@ CONTRACT_TYPE:NEEDS[TACLifeSupport|USILifeSupport]
 	PARAMETER:NEEDS[USILifeSupport]
 	{
 		name = Self-Sufficiency
-		type = PartValidation
+		type = any
 		
-		FILTER
+		title = Have at least one life support recycler, cultivator, or agroponics unit
+		
+		PARAMETER
 		{
-			MODULE
+			name = usi-converter
+			type = PartValidation
+		
+			FILTER
 			{
-				name = ModuleResourceConverter
-				
-				INPUT_RESOURCE
+				MODULE
 				{
-					ResourceName = Mulch
+					name = ModuleResourceConverter_USI
+					
+					// don't restrict inputs to allow different types of recycler/greenhouse modules
+					OUTPUT_RESOURCE
+					{
+						ResourceName = Supplies
+					}
 				}
-				OUTPUT_RESOURCE
+			}
+		}		
+
+		PARAMETER
+		{
+			// legacy is still used by some mods with outdated USI-LS compatibility patches
+			name = legacy-converter
+			type = PartValidation
+		
+			FILTER
+			{
+				MODULE
 				{
-					ResourceName = Supplies
-				}
-			}	
+					name = ModuleResourceConverter
+					
+					INPUT_RESOURCE
+					{
+						ResourceName = Mulch
+					}
+					OUTPUT_RESOURCE
+					{
+						ResourceName = Supplies
+					}
+				}	
+			}
 		}
+		
+		PARAMETER
+		{
+			name = kpbs-converter
+			type = PartValidation
+		
+			FILTER
+			{
+				MODULE
+				{
+					name = ModuleKPBSConverter
+					
+					// don't restrict inputs to allow different types of recycler/greenhouse modules
+					OUTPUT_RESOURCE
+					{
+						ResourceName = Supplies
+					}
+				}
+			}
+		}		
 	}
 	PARAMETER
     {


### PR DESCRIPTION
ModuleResourceConverter is only used as a USI-LS recycler by some mods with outdated USI-LS patches.

USI now uses ModuleResourceConverter_USI internally