### PR TITLE
Fix typo in previously submitted patch

### DIFF
--- a/BaseMissions/BaseSelf-Sufficiency.cfg
+++ b/BaseMissions/BaseSelf-Sufficiency.cfg
@@ -72,7 +72,7 @@ CONTRACT_TYPE:NEEDS[TACLifeSupport|USILifeSupport]
 	PARAMETER:NEEDS[USILifeSupport]
 	{
 		name = Self-Sufficiency
-		type = any
+		type = Any
 		
 		title = Have at least one life support recycler, cultivator, or agroponics unit
 		


### PR DESCRIPTION
Base self-sufficiency patch contained a typo. "Any" parameter is case sensitive.